### PR TITLE
Implements mod config using cloth

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,12 +15,22 @@ minecraft {
 sourceSets.main.java.srcDirs += 'java'
 sourceSets.main.resources.srcDirs += 'resources'
 
+repositories {
+	mavenLocal()
+    mavenCentral()
+    maven { url "https://maven.shedaniel.me/" }
+}
+
 dependencies {
 	minecraft "com.mojang:minecraft:${project.minecraft_version}"
 	mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
 	modCompile "net.fabricmc:fabric-loader:${project.loader_version}"
 
 	modCompile "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
+
+	modApi("me.shedaniel.cloth:cloth-config-fabric:${project.cloth_version}") {
+        exclude(group: "net.fabricmc.fabric-api")
+    }
 }
 
 processResources {

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '0.4-SNAPSHOT'
+	id 'fabric-loom' version '0.7-SNAPSHOT'
 	id 'maven-publish'
 }
 
@@ -16,9 +16,9 @@ sourceSets.main.java.srcDirs += 'java'
 sourceSets.main.resources.srcDirs += 'resources'
 
 repositories {
+    maven { url "https://maven.shedaniel.me/" }
 	mavenLocal()
     mavenCentral()
-    maven { url "https://maven.shedaniel.me/" }
 }
 
 dependencies {
@@ -28,6 +28,7 @@ dependencies {
 
 	modCompile "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 
+	modImplementation "io.github.prospector:modmenu:${project.modmenu_version}"
 	modApi("me.shedaniel.cloth:cloth-config-fabric:${project.cloth_version}") {
         exclude(group: "net.fabricmc.fabric-api")
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,6 +8,9 @@ yarn_mappings=1.16+build.1
 loader_version=0.8.8+build.202
 fabric_version=0.13.1+build.370-1.16
 
+# Third-party Properties
+cloth_version=4.10.11
+
 # Mod Properties
 maven_group = squeek.appleskin
 archives_base_name = appleskin

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,14 +2,15 @@
 org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
-# check these on https://fabricmc.net/use
-minecraft_version=1.16
-yarn_mappings=1.16+build.1
-loader_version=0.8.8+build.202
-fabric_version=0.13.1+build.370-1.16
+# check these on https://fabricmc.net/versions.html
+minecraft_version=1.16.4
+yarn_mappings=1.16.4+build.9
+loader_version=0.11.3
+fabric_version=0.34.2+1.16
 
 # Third-party Properties
-cloth_version=4.10.11
+cloth_version=4.11.26
+modmenu_version=1.14.9+build.14
 
 # Mod Properties
 maven_group = squeek.appleskin

--- a/java/squeek/appleskin/AppleSkin.java
+++ b/java/squeek/appleskin/AppleSkin.java
@@ -9,5 +9,6 @@ public class AppleSkin implements ClientModInitializer
 	public void onInitializeClient()
 	{
 		SyncHandler.init();
+		ModConfig.init();
 	}
 }

--- a/java/squeek/appleskin/ModConfig.java
+++ b/java/squeek/appleskin/ModConfig.java
@@ -1,0 +1,40 @@
+package squeek.appleskin;
+
+import me.shedaniel.autoconfig.AutoConfig;
+import me.shedaniel.autoconfig.ConfigData;
+import me.shedaniel.autoconfig.annotation.Config;
+import me.shedaniel.autoconfig.serializer.JanksonConfigSerializer;
+import me.shedaniel.cloth.clothconfig.shadowed.blue.endless.jankson.Comment;
+
+
+@Config(name = "appleskin-client")
+public class ModConfig implements ConfigData {
+
+    public static ModConfig INSTANCE;
+
+    public static void init() {
+        AutoConfig.register(ModConfig.class, JanksonConfigSerializer::new);
+        INSTANCE = AutoConfig.getConfigHolder(ModConfig.class).getConfig();
+    }
+
+    @Comment("If true, shows the hunger and saturation values of food in its tooltip while holding SHIFT")
+    public boolean showFoodValuesInTooltip = true;
+
+    @Comment("If true, shows the hunger and saturation values of food in its tooltip automatically (without needing to hold SHIFT)")
+    public boolean showFoodValuesInTooltipAlways = true;
+
+    @Comment("If true, shows your current saturation level overlayed on the hunger bar")
+    public boolean showSaturationHudOverlay = true;
+
+    @Comment("If true, shows the hunger (and saturation if showSaturationHudOverlay is true) that would be restored by food you are currently holding")
+    public boolean showFoodValuesHudOverlay = true;
+
+    @Comment("If true, shows the hunger (and saturation if showSaturationHudOverlay is true) that would be restored by food you are offhand holding")
+    public boolean showFoodValuesHudOverlayWhenOffhand = true;
+
+    @Comment("If true, shows your food exhaustion as a progress bar behind the hunger bars")
+    public boolean showFoodExhaustionHudUnderlay = true;
+
+    @Comment("If true, adds a line that shows your hunger, saturation, and exhaustion level in the F3 debug overlay")
+    public boolean showFoodStatsInDebugOverlay = true;
+}

--- a/java/squeek/appleskin/ModConfig.java
+++ b/java/squeek/appleskin/ModConfig.java
@@ -3,13 +3,15 @@ package squeek.appleskin;
 import me.shedaniel.autoconfig.AutoConfig;
 import me.shedaniel.autoconfig.ConfigData;
 import me.shedaniel.autoconfig.annotation.Config;
+import me.shedaniel.autoconfig.annotation.ConfigEntry;
 import me.shedaniel.autoconfig.serializer.JanksonConfigSerializer;
 import me.shedaniel.cloth.clothconfig.shadowed.blue.endless.jankson.Comment;
 
 
-@Config(name = "appleskin-client")
+@Config(name = "appleskin")
 public class ModConfig implements ConfigData {
 
+    @ConfigEntry.Gui.Excluded
     public static ModConfig INSTANCE;
 
     public static void init() {
@@ -34,7 +36,6 @@ public class ModConfig implements ConfigData {
 
     @Comment("If true, shows your food exhaustion as a progress bar behind the hunger bars")
     public boolean showFoodExhaustionHudUnderlay = true;
-
-    @Comment("If true, adds a line that shows your hunger, saturation, and exhaustion level in the F3 debug overlay")
-    public boolean showFoodStatsInDebugOverlay = true;
 }
+
+

--- a/java/squeek/appleskin/client/TooltipOverlayHandler.java
+++ b/java/squeek/appleskin/client/TooltipOverlayHandler.java
@@ -8,9 +8,11 @@ import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.text.LiteralText;
 import net.minecraft.util.Identifier;
+import squeek.appleskin.ModConfig;
 import squeek.appleskin.api.event.TooltipOverlayEvent;
 import squeek.appleskin.api.food.IFood;
 import squeek.appleskin.helpers.FoodHelper;
+import squeek.appleskin.helpers.KeyHelper;
 
 import java.util.List;
 
@@ -325,6 +327,11 @@ public class TooltipOverlayHandler
 	private static boolean shouldShowTooltip(ItemStack hoveredStack)
 	{
 		if (hoveredStack.isEmpty()) {
+			return false;
+		}
+
+		boolean shouldShowTooltip = (ModConfig.INSTANCE.showFoodValuesInTooltip && KeyHelper.isShiftKeyDown()) || ModConfig.INSTANCE.showFoodValuesInTooltipAlways;
+		if (!shouldShowTooltip) {
 			return false;
 		}
 

--- a/java/squeek/appleskin/gui/ModMenuIntegration.java
+++ b/java/squeek/appleskin/gui/ModMenuIntegration.java
@@ -1,0 +1,16 @@
+package squeek.appleskin.gui;
+
+import io.github.prospector.modmenu.api.ConfigScreenFactory;
+import io.github.prospector.modmenu.api.ModMenuApi;
+import me.shedaniel.autoconfig.AutoConfig;
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import squeek.appleskin.ModConfig;
+
+@Environment(EnvType.CLIENT)
+public class ModMenuIntegration implements ModMenuApi {
+    @Override
+    public ConfigScreenFactory<?> getModConfigScreenFactory() {
+        return parent -> AutoConfig.getConfigScreen(ModConfig.class, parent).get();
+    }
+}

--- a/java/squeek/appleskin/helpers/KeyHelper.java
+++ b/java/squeek/appleskin/helpers/KeyHelper.java
@@ -1,0 +1,25 @@
+package squeek.appleskin.helpers;
+
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.util.InputUtil;
+import org.lwjgl.glfw.GLFW;
+
+public class KeyHelper
+{
+    public static boolean isCtrlKeyDown()
+    {
+        long handle = MinecraftClient.getInstance().getWindow().getHandle();
+        // prioritize CONTROL, but allow OPTION as well on Mac (note: GuiScreen's isCtrlKeyDown only checks for the OPTION key on Mac)
+        boolean isCtrlKeyDown = InputUtil.isKeyPressed(handle, GLFW.GLFW_KEY_LEFT_CONTROL) || InputUtil.isKeyPressed(handle, GLFW.GLFW_KEY_RIGHT_CONTROL);
+        if (!isCtrlKeyDown && MinecraftClient.IS_SYSTEM_MAC)
+            isCtrlKeyDown = InputUtil.isKeyPressed(handle, GLFW.GLFW_KEY_LEFT_SUPER) || InputUtil.isKeyPressed(handle, GLFW.GLFW_KEY_RIGHT_SUPER);
+
+        return isCtrlKeyDown;
+    }
+
+    public static boolean isShiftKeyDown()
+    {
+        long handle = MinecraftClient.getInstance().getWindow().getHandle();
+        return InputUtil.isKeyPressed(handle, GLFW.GLFW_KEY_LEFT_SHIFT) || InputUtil.isKeyPressed(handle, GLFW.GLFW_KEY_RIGHT_SHIFT);
+    }
+}

--- a/java/squeek/appleskin/mixin/GuiMixin.java
+++ b/java/squeek/appleskin/mixin/GuiMixin.java
@@ -22,7 +22,7 @@ public class GuiMixin
 		TooltipOverlayHandler.onItemTooltip(itemStack, info.getReturnValue());
 	}
 
-	@Inject(at = @At(value = "INVOKE", target = "Lnet/minecraft/client/util/math/MatrixStack;push()V", ordinal = 0), locals = LocalCapture.CAPTURE_FAILHARD, method = "renderTooltip(Lnet/minecraft/client/util/math/MatrixStack;Ljava/util/List;II)V")
+	@Inject(at = @At(value = "INVOKE", target = "Lnet/minecraft/client/util/math/MatrixStack;push()V", ordinal = 0), locals = LocalCapture.CAPTURE_FAILHARD, method = "renderOrderedTooltip(Lnet/minecraft/client/util/math/MatrixStack;Ljava/util/List;II)V")
 	private void renderTooltip(MatrixStack matrixStack, List tooltip, int mouseX, int mouseY, CallbackInfo info, int w, int x, int y, int w2, int h)
 	{
 		TooltipOverlayHandler.onRenderTooltip(matrixStack, tooltip, x, y, w, h);

--- a/resources/assets/appleskin/lang/en_us.json
+++ b/resources/assets/appleskin/lang/en_us.json
@@ -1,0 +1,9 @@
+{
+  "text.autoconfig.appleskin.title": "Apple Skin",
+  "text.autoconfig.appleskin.option.showFoodValuesInTooltip": "Shows food in tooltip",
+  "text.autoconfig.appleskin.option.showFoodValuesInTooltipAlways": "Shows food in tooltip by automatically",
+  "text.autoconfig.appleskin.option.showFoodValuesHudOverlay": "Shows main-hand food in HUD",
+  "text.autoconfig.appleskin.option.showFoodValuesHudOverlayWhenOffhand": "Shows off-hand food in HUD",
+  "text.autoconfig.appleskin.option.showFoodExhaustionHudUnderlay": "Shows exhaustion level in HUD",
+  "text.autoconfig.appleskin.option.showSaturationHudOverlay": "Shows saturation level in HUD"
+}

--- a/resources/fabric.mod.json
+++ b/resources/fabric.mod.json
@@ -21,6 +21,9 @@
   "entrypoints": {
     "client": [
       "squeek.appleskin.AppleSkin"
+    ],
+    "modmenu": [
+      "squeek.appleskin.gui.ModMenuIntegration"
     ]
   },
   "mixins": [


### PR DESCRIPTION
1. The implementation of `Screen.renderTooltip` changed in 1.16.4 and 1.16.5

2. Because `en_us.json` strings to be display on the screen, so these need concise names. 
I tried to write some, but i don't feel good, maybe you could arrange a better name for it.

3. Because cloth `toml` does not display comments,  currently using the `JSON` version config.

Show In ModMenu:

![2021-05-25_17 07 46](https://user-images.githubusercontent.com/6903353/119474808-225dc900-bd7f-11eb-85d6-a6c1b0c49c42.png)

Show In Cloth Config Screen:

![2021-05-25_17 09 48](https://user-images.githubusercontent.com/6903353/119474820-24c02300-bd7f-11eb-84d8-2772b8121272.png)
