### PR TITLE
Implementation the show food estimated health in HUD - Fabric 1.16

### DIFF
--- a/java/squeek/appleskin/ModConfig.java
+++ b/java/squeek/appleskin/ModConfig.java
@@ -33,16 +33,16 @@ public class ModConfig implements ConfigData
 	@Comment("If true, shows the hunger (and saturation if showSaturationHudOverlay is true) that would be restored by food you are currently holding")
 	public boolean showFoodValuesHudOverlay = true;
 
-	@Comment("If true, shows the hunger (and saturation if showSaturationHudOverlay is true) that would be restored by food you are offhand holding")
+	@Comment("If true, enables the hunger/saturation/health overlays for food in your off-hand")
 	public boolean showFoodValuesHudOverlayWhenOffhand = true;
 
-	@Comment("If true, shows your food exhaustion as a progress bar behind the hunger bars")
+	@Comment("If true, shows your food exhaustion as a progress bar behind the hunger bar")
 	public boolean showFoodExhaustionHudUnderlay = true;
 
-	@Comment("If true, shows estimated health by food on the health bars")
+	@Comment("If true, shows estimated health restored by food on the health bar")
 	public boolean showFoodHealthHudOverlay = true;
 
-	@Comment("If true, shows vanilla heartbeat/hunger animation in Hud")
+	@Comment("If true, health/hunger overlay will shake to match Minecraft's icon animations")
 	public boolean showVanillaAnimationsOverlay = true;
 }
 

--- a/java/squeek/appleskin/ModConfig.java
+++ b/java/squeek/appleskin/ModConfig.java
@@ -38,6 +38,12 @@ public class ModConfig implements ConfigData
 
 	@Comment("If true, shows your food exhaustion as a progress bar behind the hunger bars")
 	public boolean showFoodExhaustionHudUnderlay = true;
+
+	@Comment("If true, shows estimated health by food on the health bars")
+	public boolean showFoodHealthHudOverlay = true;
+
+	@Comment("If true, shows vanilla heartbeat/hunger animation in Hud")
+	public boolean showVanillaAnimationsOverlay = true;
 }
 
 

--- a/java/squeek/appleskin/api/event/HUDOverlayEvent.java
+++ b/java/squeek/appleskin/api/event/HUDOverlayEvent.java
@@ -60,6 +60,26 @@ public class HUDOverlayEvent
 		public static Event<EventHandler<HungerRestored>> EVENT = EventHandler.createArrayBacked();
 	}
 
+	/**
+	 * If cancelled, will stop all rendering of the estimated health overlay.
+	 */
+	public static class HealthRestored extends HUDOverlayEvent
+	{
+		public HealthRestored(float modifiedHealth, ItemStack itemStack, FoodValues foodValues, int x, int y, MatrixStack matrixStack)
+		{
+			super(x, y, matrixStack);
+			this.modifiedHealth = modifiedHealth;
+			this.itemStack = itemStack;
+			this.foodValues = foodValues;
+		}
+
+		public final FoodValues foodValues;
+		public final ItemStack itemStack;
+		public final float modifiedHealth;
+
+		public static Event<EventHandler<HealthRestored>> EVENT = EventHandler.createArrayBacked();
+	}
+
 	private HUDOverlayEvent(int x, int y, MatrixStack matrixStack)
 	{
 		this.x = x;

--- a/java/squeek/appleskin/client/HUDOverlayHandler.java
+++ b/java/squeek/appleskin/client/HUDOverlayHandler.java
@@ -5,7 +5,6 @@ import com.mojang.blaze3d.systems.RenderSystem;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.util.math.MatrixStack;
-import net.minecraft.entity.attribute.EntityAttributes;
 import net.minecraft.entity.effect.StatusEffects;
 import net.minecraft.entity.player.HungerManager;
 import net.minecraft.entity.player.PlayerEntity;
@@ -91,7 +90,7 @@ public class HUDOverlayHandler
 
 		// draw saturation overlay
 		if (!saturationRenderEvent.isCanceled)
-			drawSaturationOverlay(saturationRenderEvent, mc, 0, 1f);
+			drawSaturationOverlay(saturationRenderEvent, mc, 0, 1F);
 
 		// try to get the item stack in the player hand
 		ItemStack heldItem = player.getMainHandStack();
@@ -440,11 +439,11 @@ public class HUDOverlayHandler
 		final int preferHealthBars = 10;
 		final int preferFoodBars = 10;
 
-		final float maxHealth = (float)player.getAttributeValue(EntityAttributes.GENERIC_MAX_HEALTH);
+		final float maxHealth = player.getMaxHealth();
 		final float absorptionHealth = (float)Math.ceil(player.getAbsorptionAmount());
 
 		int healthBars = (int)Math.ceil((maxHealth + absorptionHealth) / 2.0F);
-		int healthRows = (int)Math.ceil((float)healthBars / 10.0F);
+		int healthRows = (int)Math.ceil((float)healthBars / (float)preferHealthBars);
 
 		int healthRowHeight = Math.max(10 - (healthRows - 2), 3);
 

--- a/java/squeek/appleskin/helpers/FoodHelper.java
+++ b/java/squeek/appleskin/helpers/FoodHelper.java
@@ -100,25 +100,25 @@ public class FoodHelper
 		float exhaustionForRegen = 6.0F;
 		float exhaustionForConsumed = 4.0F;
 
-		while (foodLevel >= 18) {
-			while (exhaustionLevel > exhaustionForConsumed) {
+		while (foodLevel >= 18)
+		{
+			while (exhaustionLevel > exhaustionForConsumed)
+			{
 				exhaustionLevel -= exhaustionForConsumed;
-				if (saturationLevel > 0) {
+				if (saturationLevel > 0)
 					saturationLevel = Math.max(saturationLevel - 1, 0);
-				} else {
+				else
 					foodLevel -= 1;
-				}
 			}
-			// accumulated exhaustion is too high, can't regen health
-			if (foodLevel < 18) {
-				break;
-			}
-			if (saturationLevel > 0) {
+			if (foodLevel >= 20 && saturationLevel > 0)
+			{
 				// fast regen health
 				float limitedSaturationLevel = Math.min(saturationLevel, exhaustionForRegen);
 				health += limitedSaturationLevel / exhaustionForRegen;
 				exhaustionLevel += limitedSaturationLevel;
-			} else {
+			}
+			else if (foodLevel >= 18)
+			{
 				// slow regen health
 				health += 1;
 				exhaustionLevel += exhaustionForRegen;

--- a/java/squeek/appleskin/helpers/FoodHelper.java
+++ b/java/squeek/appleskin/helpers/FoodHelper.java
@@ -44,47 +44,49 @@ public class FoodHelper
 		if (!isFood(itemStack))
 			return false;
 
-		for (Pair<StatusEffectInstance, Float> effect : itemStack.getItem().getFoodComponent().getStatusEffects()) {
-			if (effect.getFirst() != null && effect.getFirst().getEffectType() != null && effect.getFirst().getEffectType().getType() == StatusEffectType.HARMFUL) {
+		for (Pair<StatusEffectInstance, Float> effect : itemStack.getItem().getFoodComponent().getStatusEffects())
+		{
+			if (effect.getFirst() != null && effect.getFirst().getEffectType() != null && effect.getFirst().getEffectType().getType() == StatusEffectType.HARMFUL)
 				return true;
-			}
 		}
 		return false;
 	}
 
-	public static float getEstimatedHealthIncrement(ItemStack itemStack, PlayerEntity player)
+	public static float getEstimatedHealthIncrement(ItemStack itemStack, FoodValues modifiedFoodValues, PlayerEntity player)
 	{
 		if (!isFood(itemStack))
 			return 0;
 
-		if (!player.canFoodHeal()) {
+		if (!player.canFoodHeal())
 			return 0;
-		}
 
 		HungerManager stats = player.getHungerManager();
 		World world = player.getEntityWorld();
 
-		FoodValues foodValues = getModifiedFoodValues(itemStack, player);
-
-		int foodLevel = Math.min(stats.getFoodLevel() + foodValues.hunger, 20);
+		int foodLevel = Math.min(stats.getFoodLevel() + modifiedFoodValues.hunger, 20);
 		float healthIncrement = 0;
 
 		// health for natural regen
-		if (foodLevel >= 18.0F && world != null && world.getGameRules().getBoolean(GameRules.NATURAL_REGENERATION)) {
-			float saturationLevel = Math.min(stats.getSaturationLevel() + foodValues.getSaturationIncrement(), (float)foodLevel);
+		if (foodLevel >= 18.0F && world != null && world.getGameRules().getBoolean(GameRules.NATURAL_REGENERATION))
+		{
+			float saturationLevel = Math.min(stats.getSaturationLevel() + modifiedFoodValues.getSaturationIncrement(), (float)foodLevel);
 			float exhaustionLevel = HungerHelper.getExhaustion(player);
 			healthIncrement = getEstimatedHealthIncrement(foodLevel, saturationLevel, exhaustionLevel);
 		}
 
 		// health for regeneration effect
-		for (Pair<StatusEffectInstance, Float> effect : itemStack.getItem().getFoodComponent().getStatusEffects()) {
+		for (Pair<StatusEffectInstance, Float> effect : itemStack.getItem().getFoodComponent().getStatusEffects())
+		{
 			StatusEffectInstance effectInstance = effect.getFirst();
-			if (effectInstance != null && effectInstance.getEffectType() == StatusEffects.REGENERATION) {
+			if (effectInstance != null && effectInstance.getEffectType() == StatusEffects.REGENERATION)
+			{
 				int amplifier = effectInstance.getAmplifier();
 				int duration = effectInstance.getDuration();
-				if (effectInstance.isPermanent()) {
+
+				// when is a permanent status effect, just have to make a big duration
+				if (effectInstance.isPermanent())
 					duration = Integer.MAX_VALUE;
-				}
+
 				healthIncrement += (float)Math.floor(duration / (50 >> amplifier));
 				break;
 			}
@@ -95,7 +97,6 @@ public class FoodHelper
 
 	public static float getEstimatedHealthIncrement(int foodLevel, float saturationLevel, float exhaustionLevel)
 	{
-
 		float health = 0;
 		float exhaustionForRegen = 6.0F;
 		float exhaustionForConsumed = 4.0F;

--- a/java/squeek/appleskin/helpers/FoodHelper.java
+++ b/java/squeek/appleskin/helpers/FoodHelper.java
@@ -120,7 +120,10 @@ public class FoodHelper
 		while (foodLevel >= 18) {
 			if (exhaustionLevel > exhaustionForConsumed) {
 				exhaustionLevel -= exhaustionForConsumed;
-				foodLevel -= 1;
+				if (saturationLevel > 0)
+					saturationLevel = Math.max(saturationLevel - 1f, 0f);
+				else
+					foodLevel -= 1;
 			}
 			++foodStarvationTimer;
 			if (foodStarvationTimer < 80) {

--- a/java/squeek/appleskin/helpers/FoodHelper.java
+++ b/java/squeek/appleskin/helpers/FoodHelper.java
@@ -100,16 +100,6 @@ public class FoodHelper
 		float exhaustionForRegen = 6.0F;
 		float exhaustionForConsumed = 4.0F;
 
-		while (foodLevel >= 20 && saturationLevel > 0) {
-			while (exhaustionLevel > exhaustionForConsumed) {
-				exhaustionLevel -= exhaustionForConsumed;
-				saturationLevel = Math.max(saturationLevel - 1, 0);
-			}
-			float limitedSaturationLevel = Math.min(saturationLevel, exhaustionForRegen);
-			health += limitedSaturationLevel / exhaustionForRegen;
-			exhaustionLevel += limitedSaturationLevel;
-		}
-
 		while (foodLevel >= 18) {
 			while (exhaustionLevel > exhaustionForConsumed) {
 				exhaustionLevel -= exhaustionForConsumed;
@@ -119,8 +109,20 @@ public class FoodHelper
 					foodLevel -= 1;
 				}
 			}
-			health += 1;
-			exhaustionLevel += exhaustionForRegen;
+			// accumulated exhaustion is too high, can't regen health
+			if (foodLevel < 18) {
+				break;
+			}
+			if (saturationLevel > 0) {
+				// fast regen health
+				float limitedSaturationLevel = Math.min(saturationLevel, exhaustionForRegen);
+				health += limitedSaturationLevel / exhaustionForRegen;
+				exhaustionLevel += limitedSaturationLevel;
+			} else {
+				// slow regen health
+				health += 1;
+				exhaustionLevel += exhaustionForRegen;
+			}
 		}
 
 		return health;

--- a/java/squeek/appleskin/helpers/FoodHelper.java
+++ b/java/squeek/appleskin/helpers/FoodHelper.java
@@ -100,38 +100,27 @@ public class FoodHelper
 		float exhaustionForRegen = 6.0F;
 		float exhaustionForConsumed = 4.0F;
 
-		// using timer is still used to avoid some boundary problems
-		int foodStarvationTimer = 0;
 		while (foodLevel >= 20 && saturationLevel > 0) {
 			while (exhaustionLevel > exhaustionForConsumed) {
 				exhaustionLevel -= exhaustionForConsumed;
 				saturationLevel = Math.max(saturationLevel - 1, 0);
 			}
-			++foodStarvationTimer;
-			if (foodStarvationTimer < 10) {
-				continue;
-			}
 			float limitedSaturationLevel = Math.min(saturationLevel, exhaustionForRegen);
 			health += limitedSaturationLevel / exhaustionForRegen;
 			exhaustionLevel += limitedSaturationLevel;
-			foodStarvationTimer = 0;
 		}
 
 		while (foodLevel >= 18) {
-			if (exhaustionLevel > exhaustionForConsumed) {
+			while (exhaustionLevel > exhaustionForConsumed) {
 				exhaustionLevel -= exhaustionForConsumed;
-				if (saturationLevel > 0)
-					saturationLevel = Math.max(saturationLevel - 1f, 0f);
-				else
+				if (saturationLevel > 0) {
+					saturationLevel = Math.max(saturationLevel - 1, 0);
+				} else {
 					foodLevel -= 1;
-			}
-			++foodStarvationTimer;
-			if (foodStarvationTimer < 80) {
-				continue;
+				}
 			}
 			health += 1;
 			exhaustionLevel += exhaustionForRegen;
-			foodStarvationTimer = 0;
 		}
 
 		return health;

--- a/java/squeek/appleskin/helpers/FoodHelper.java
+++ b/java/squeek/appleskin/helpers/FoodHelper.java
@@ -3,9 +3,13 @@ package squeek.appleskin.helpers;
 import com.mojang.datafixers.util.Pair;
 import net.minecraft.entity.effect.StatusEffectInstance;
 import net.minecraft.entity.effect.StatusEffectType;
+import net.minecraft.entity.effect.StatusEffects;
+import net.minecraft.entity.player.HungerManager;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.FoodComponent;
 import net.minecraft.item.ItemStack;
+import net.minecraft.world.GameRules;
+import net.minecraft.world.World;
 import squeek.appleskin.api.food.FoodValues;
 
 public class FoodHelper
@@ -40,13 +44,93 @@ public class FoodHelper
 		if (!isFood(itemStack))
 			return false;
 
-		for (Pair<StatusEffectInstance, Float> effect : itemStack.getItem().getFoodComponent().getStatusEffects())
-		{
-			if (effect.getFirst() != null && effect.getFirst().getEffectType() != null && effect.getFirst().getEffectType().getType() == StatusEffectType.HARMFUL)
-			{
+		for (Pair<StatusEffectInstance, Float> effect : itemStack.getItem().getFoodComponent().getStatusEffects()) {
+			if (effect.getFirst() != null && effect.getFirst().getEffectType() != null && effect.getFirst().getEffectType().getType() == StatusEffectType.HARMFUL) {
 				return true;
 			}
 		}
 		return false;
+	}
+
+	public static float getEstimatedHealthIncrement(ItemStack itemStack, PlayerEntity player)
+	{
+		if (!isFood(itemStack))
+			return 0;
+
+		if (!player.canFoodHeal()) {
+			return 0;
+		}
+
+		HungerManager stats = player.getHungerManager();
+		World world = player.getEntityWorld();
+
+		FoodValues foodValues = getModifiedFoodValues(itemStack, player);
+
+		int foodLevel = Math.min(stats.getFoodLevel() + foodValues.hunger, 20);
+		float healthIncrement = 0;
+
+		// health for natural regen
+		if (foodLevel >= 18.0F && world != null && world.getGameRules().getBoolean(GameRules.NATURAL_REGENERATION)) {
+			float saturationLevel = Math.min(stats.getSaturationLevel() + foodValues.getSaturationIncrement(), (float)foodLevel);
+			float exhaustionLevel = HungerHelper.getExhaustion(player);
+			healthIncrement = getEstimatedHealthIncrement(foodLevel, saturationLevel, exhaustionLevel);
+		}
+
+		// health for regeneration effect
+		for (Pair<StatusEffectInstance, Float> effect : itemStack.getItem().getFoodComponent().getStatusEffects()) {
+			StatusEffectInstance effectInstance = effect.getFirst();
+			if (effectInstance != null && effectInstance.getEffectType() == StatusEffects.REGENERATION) {
+				int amplifier = effectInstance.getAmplifier();
+				int duration = effectInstance.getDuration();
+				if (effectInstance.isPermanent()) {
+					duration = Integer.MAX_VALUE;
+				}
+				healthIncrement += (float)Math.floor(duration / (50 >> amplifier));
+				break;
+			}
+		}
+
+		return healthIncrement;
+	}
+
+	public static float getEstimatedHealthIncrement(int foodLevel, float saturationLevel, float exhaustionLevel)
+	{
+
+		float health = 0;
+		float exhaustionForRegen = 6.0F;
+		float exhaustionForConsumed = 4.0F;
+
+		// using timer is still used to avoid some boundary problems
+		int foodStarvationTimer = 0;
+		while (foodLevel >= 20 && saturationLevel > 0) {
+			if (exhaustionLevel > exhaustionForConsumed) {
+				exhaustionLevel -= exhaustionForConsumed;
+				saturationLevel = Math.max(saturationLevel - 1, 0);
+			}
+			++foodStarvationTimer;
+			if (foodStarvationTimer < 10) {
+				continue;
+			}
+			float limitedSaturationLevel = Math.min(saturationLevel, exhaustionForRegen);
+			health += limitedSaturationLevel / exhaustionForRegen;
+			exhaustionLevel += limitedSaturationLevel;
+			foodStarvationTimer = 0;
+		}
+
+		while (foodLevel >= 18) {
+			if (exhaustionLevel > exhaustionForConsumed) {
+				exhaustionLevel -= exhaustionForConsumed;
+				foodLevel -= 1;
+			}
+			++foodStarvationTimer;
+			if (foodStarvationTimer < 80) {
+				continue;
+			}
+			health += 1;
+			exhaustionLevel += exhaustionForRegen;
+			foodStarvationTimer = 0;
+		}
+
+		return health;
 	}
 }

--- a/java/squeek/appleskin/helpers/FoodHelper.java
+++ b/java/squeek/appleskin/helpers/FoodHelper.java
@@ -103,7 +103,7 @@ public class FoodHelper
 		// using timer is still used to avoid some boundary problems
 		int foodStarvationTimer = 0;
 		while (foodLevel >= 20 && saturationLevel > 0) {
-			if (exhaustionLevel > exhaustionForConsumed) {
+			while (exhaustionLevel > exhaustionForConsumed) {
 				exhaustionLevel -= exhaustionForConsumed;
 				saturationLevel = Math.max(saturationLevel - 1, 0);
 			}

--- a/java/squeek/appleskin/util/IntPoint.java
+++ b/java/squeek/appleskin/util/IntPoint.java
@@ -1,0 +1,7 @@
+package squeek.appleskin.util;
+
+public class IntPoint
+{
+    public int x;
+    public int y;
+}

--- a/resources/assets/appleskin/lang/en_us.json
+++ b/resources/assets/appleskin/lang/en_us.json
@@ -2,7 +2,7 @@
   "text.autoconfig.appleskin.title": "AppleSkin",
   "text.autoconfig.appleskin.option.showFoodValuesInTooltip": "Show food values in tooltip",
   "text.autoconfig.appleskin.option.showFoodValuesInTooltipAlways": "Always show food values in tooltip",
-  "text.autoconfig.appleskin.option.showFoodValuesHudOverlay": "Show hunger restored when holding food",
+  "text.autoconfig.appleskin.option.showFoodValuesHudOverlay": "Show holding food values in HUD",
   "text.autoconfig.appleskin.option.showFoodValuesHudOverlayWhenOffhand": "Show hunger restored from food in off-hand",
   "text.autoconfig.appleskin.option.showFoodExhaustionHudUnderlay": "Show exhaustion underlay",
   "text.autoconfig.appleskin.option.showSaturationHudOverlay": "Show saturation overlay"

--- a/resources/assets/appleskin/lang/en_us.json
+++ b/resources/assets/appleskin/lang/en_us.json
@@ -2,10 +2,10 @@
   "text.autoconfig.appleskin.title": "AppleSkin",
   "text.autoconfig.appleskin.option.showFoodValuesInTooltip": "Show food values in tooltip",
   "text.autoconfig.appleskin.option.showFoodValuesInTooltipAlways": "Always show food values in tooltip",
-  "text.autoconfig.appleskin.option.showFoodValuesHudOverlay": "Show holding food values in Hud",
+  "text.autoconfig.appleskin.option.showFoodValuesHudOverlay": "Show hunger restored from held food",
   "text.autoconfig.appleskin.option.showFoodValuesHudOverlayWhenOffhand": "Show hunger restored from food in off-hand",
   "text.autoconfig.appleskin.option.showFoodHealthHudOverlay": "Show estimated health overlay",
   "text.autoconfig.appleskin.option.showFoodExhaustionHudUnderlay": "Show exhaustion underlay",
   "text.autoconfig.appleskin.option.showSaturationHudOverlay": "Show saturation overlay",
-  "text.autoconfig.appleskin.option.showVanillaAnimationsInHud": "show vanilla heartbeat/hunger animation"
+  "text.autoconfig.appleskin.option.showVanillaAnimationsOverlay": "Animate HUD icons to match Minecraft"
 }

--- a/resources/assets/appleskin/lang/en_us.json
+++ b/resources/assets/appleskin/lang/en_us.json
@@ -2,8 +2,10 @@
   "text.autoconfig.appleskin.title": "AppleSkin",
   "text.autoconfig.appleskin.option.showFoodValuesInTooltip": "Show food values in tooltip",
   "text.autoconfig.appleskin.option.showFoodValuesInTooltipAlways": "Always show food values in tooltip",
-  "text.autoconfig.appleskin.option.showFoodValuesHudOverlay": "Show holding food values in HUD",
+  "text.autoconfig.appleskin.option.showFoodValuesHudOverlay": "Show holding food values in Hud",
   "text.autoconfig.appleskin.option.showFoodValuesHudOverlayWhenOffhand": "Show hunger restored from food in off-hand",
+  "text.autoconfig.appleskin.option.showFoodHealthHudOverlay": "Show estimated health overlay",
   "text.autoconfig.appleskin.option.showFoodExhaustionHudUnderlay": "Show exhaustion underlay",
-  "text.autoconfig.appleskin.option.showSaturationHudOverlay": "Show saturation overlay"
+  "text.autoconfig.appleskin.option.showSaturationHudOverlay": "Show saturation overlay",
+  "text.autoconfig.appleskin.option.showVanillaAnimationsInHud": "show vanilla heartbeat/hunger animation"
 }


### PR DESCRIPTION
Fixes #56

1. ~In vanilla when health is below 5 will random move the icon, which may take some time to fix it~

2. When the player's health is changes by status effects, the estimated health won't work. 
    This is designed to avoid the player confused how much of restored healths

3. ~Need a new config option~

4. Need more tests
   - ~player has than 20 health.~
   - more GameMode
   - more game difficulty
   - ...

5. Maybe need a new branch for this