### PR TITLE
Add hunger/saturation/exhaustion info to the debug overlay - 1.17 Fabric

### DIFF
--- a/java/squeek/appleskin/AppleSkin.java
+++ b/java/squeek/appleskin/AppleSkin.java
@@ -5,6 +5,7 @@ import net.fabricmc.loader.api.FabricLoader;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import squeek.appleskin.api.AppleSkinApi;
+import squeek.appleskin.client.DebugInfoHandler;
 import squeek.appleskin.client.HUDOverlayHandler;
 import squeek.appleskin.client.TooltipOverlayHandler;
 import squeek.appleskin.network.ClientSyncHandler;
@@ -20,6 +21,7 @@ public class AppleSkin implements ClientModInitializer
 		ModConfig.init();
 		HUDOverlayHandler.init();
 		TooltipOverlayHandler.init();
+		DebugInfoHandler.init();
 		FabricLoader.getInstance().getEntrypointContainers("appleskin", AppleSkinApi.class).forEach(entrypoint -> {
 			try
 			{

--- a/java/squeek/appleskin/ModConfig.java
+++ b/java/squeek/appleskin/ModConfig.java
@@ -42,6 +42,9 @@ public class ModConfig implements ConfigData
 	@Comment("If true, shows estimated health restored by food on the health bar")
 	public boolean showFoodHealthHudOverlay = true;
 
+	@Comment("If true, shows your hunger, saturation, and exhaustion level in Debug Screen")
+	public boolean showFoodDebugInfo = true;
+
 	@Comment("If true, health/hunger overlay will shake to match Minecraft's icon animations")
 	public boolean showVanillaAnimationsOverlay = true;
 

--- a/java/squeek/appleskin/client/DebugInfoHandler.java
+++ b/java/squeek/appleskin/client/DebugInfoHandler.java
@@ -1,0 +1,46 @@
+package squeek.appleskin.client;
+
+
+
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.entity.player.HungerManager;
+import squeek.appleskin.ModConfig;
+import squeek.appleskin.helpers.FoodHelper;
+
+import java.text.DecimalFormat;
+import java.util.List;
+
+public class DebugInfoHandler
+{
+	public static DebugInfoHandler INSTANCE;
+
+	private static final DecimalFormat saturationDF = new DecimalFormat("#.##");
+	private static final DecimalFormat exhaustionValDF = new DecimalFormat("0.00");
+	private static final DecimalFormat exhaustionMaxDF = new DecimalFormat("#.##");
+
+	public static void init()
+	{
+		INSTANCE = new DebugInfoHandler();
+	}
+
+	public void onTextRender(List<String> leftDebugInfo)
+	{
+		if (leftDebugInfo == null)
+			return;
+
+		if (!ModConfig.INSTANCE.showFoodDebugInfo)
+			return;
+
+		MinecraftClient mc = MinecraftClient.getInstance();
+		if (mc == null || mc.player == null || mc.player.getHungerManager() == null)
+			return;
+
+		if (!mc.options.debugEnabled)
+			return;
+
+		HungerManager stats = mc.player.getHungerManager();
+		float curExhaustion = stats.getExhaustion();
+		float maxExhaustion = FoodHelper.MAX_EXHAUSTION;
+		leftDebugInfo.add("hunger: " + stats.getFoodLevel() + ", sat: " + saturationDF.format(stats.getSaturationLevel()) + ", exh: " + exhaustionValDF.format(curExhaustion) + "/" + exhaustionMaxDF.format(maxExhaustion));
+	}
+}

--- a/java/squeek/appleskin/mixin/DebugHudMixin.java
+++ b/java/squeek/appleskin/mixin/DebugHudMixin.java
@@ -1,0 +1,21 @@
+package squeek.appleskin.mixin;
+
+import net.minecraft.client.gui.hud.DebugHud;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import squeek.appleskin.client.DebugInfoHandler;
+
+import java.util.List;
+
+@Mixin(DebugHud.class)
+public class DebugHudMixin
+{
+	@Inject(at = @At("RETURN"), method = "getLeftText")
+	protected void getLeftText(CallbackInfoReturnable<List<String>> info)
+	{
+		if (DebugInfoHandler.INSTANCE != null)
+			DebugInfoHandler.INSTANCE.onTextRender(info.getReturnValue());
+	}
+}

--- a/resources/appleskin.mixins.json
+++ b/resources/appleskin.mixins.json
@@ -10,7 +10,8 @@
     "InGameHudMixin",
     "MinecraftClientMixin",
     "ItemStackMixin",
-    "TooltipComponentMixin"
+    "TooltipComponentMixin",
+    "DebugHudMixin"
   ],
   "injectors": {
     "defaultRequire": 1,

--- a/resources/assets/appleskin/lang/en_us.json
+++ b/resources/assets/appleskin/lang/en_us.json
@@ -7,6 +7,7 @@
   "text.autoconfig.appleskin.option.showFoodHealthHudOverlay": "Show estimated health overlay",
   "text.autoconfig.appleskin.option.showFoodExhaustionHudUnderlay": "Show exhaustion underlay",
   "text.autoconfig.appleskin.option.showSaturationHudOverlay": "Show saturation overlay",
+  "text.autoconfig.appleskin.option.showFoodDebugInfo": "Show food values in Debug Screen",
   "text.autoconfig.appleskin.option.showVanillaAnimationsOverlay": "Animate HUD icons to match Minecraft",
   "text.autoconfig.appleskin.option.maxHudOverlayFlashAlpha": "Max alpha of flashing HUD icons"
 }


### PR DESCRIPTION
Fixes #142

<img width="854" alt="image" src="https://user-images.githubusercontent.com/6903353/138594943-06d6c44f-3ce8-4b4b-8d82-f3367491d4bb.png">
