### PR TITLE
Implement development integration for forge

### DIFF
--- a/java/squeek/appleskin/AppleSkin.java
+++ b/java/squeek/appleskin/AppleSkin.java
@@ -9,10 +9,18 @@ import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import net.minecraftforge.fml.loading.FMLPaths;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import squeek.appleskin.api.AppleSkinApi;
+import squeek.appleskin.api.AppleSkinPlugin;
 import squeek.appleskin.client.DebugInfoHandler;
 import squeek.appleskin.client.HUDOverlayHandler;
 import squeek.appleskin.client.TooltipOverlayHandler;
+import squeek.appleskin.helpers.AnnotatedInstanceHelper;
 import squeek.appleskin.network.SyncHandler;
+
+
+import net.minecraftforge.fml.ModList;
+
+import java.util.List;
 
 @Mod(ModInfo.MODID)
 public class AppleSkin
@@ -43,5 +51,14 @@ public class AppleSkin
 		DebugInfoHandler.init();
 		HUDOverlayHandler.init();
 		TooltipOverlayHandler.init();
+		initAPI();
+	}
+
+	private void initAPI()
+	{
+		for (AppleSkinApi appleSkinApi : AnnotatedInstanceHelper.getModPlugins())
+		{
+			appleSkinApi.registerEvents();
+		}
 	}
 }

--- a/java/squeek/appleskin/api/AppleSkinApi.java
+++ b/java/squeek/appleskin/api/AppleSkinApi.java
@@ -1,0 +1,14 @@
+package squeek.appleskin.api;
+
+/**
+ * Used as an entrypoint in order to allow for integration with AppleSkin
+ * without depending on AppleSkin at runtime.
+ */
+public interface AppleSkinApi
+{
+	/**
+	 * Called at client-init in order for the implementer to register events with
+	 * the AppleSkin API ({@see squeek.appleskin.api.event})
+	 */
+	void registerEvents();
+}

--- a/java/squeek/appleskin/api/AppleSkinPlugin.java
+++ b/java/squeek/appleskin/api/AppleSkinPlugin.java
@@ -1,0 +1,8 @@
+package squeek.appleskin.api;
+
+/**
+ * This annotation lets AppleSking detect mod plugins.
+ * All {@link AppleSkinApi} must have this annotation and a constructor with no arguments.
+ */
+public @interface AppleSkinPlugin {
+}

--- a/java/squeek/appleskin/helpers/AnnotatedInstanceHelper.java
+++ b/java/squeek/appleskin/helpers/AnnotatedInstanceHelper.java
@@ -1,0 +1,69 @@
+package squeek.appleskin.helpers;
+
+
+import net.minecraftforge.fml.ModList;
+import net.minecraftforge.forgespi.language.ModFileScanData;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import squeek.appleskin.api.AppleSkinApi;
+import squeek.appleskin.api.AppleSkinPlugin;
+
+import org.objectweb.asm.Type;
+
+import java.lang.reflect.Constructor;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+// Ref: https://github.com/mezz/JustEnoughItems/blob/1.17/src/main/java/mezz/jei/util/AnnotatedInstanceUtil.java
+public final class AnnotatedInstanceHelper {
+    private static final Logger LOGGER = LogManager.getLogger();
+
+    private AnnotatedInstanceHelper()
+    {
+    }
+
+    public static List<AppleSkinApi> getModPlugins()
+    {
+        return getInstances(AppleSkinPlugin.class, AppleSkinApi.class);
+    }
+
+    @SuppressWarnings("SameParameterValue")
+    private static <T> List<T> getInstances(Class<?> annotationClass, Class<T> instanceClass)
+    {
+        Type annotationType = Type.getType(annotationClass);
+        List<ModFileScanData> allScanData = ModList.get().getAllScanData();
+        Set<String> pluginClassNames = new LinkedHashSet<>();
+        for (ModFileScanData scanData : allScanData)
+        {
+            Iterable<ModFileScanData.AnnotationData> annotations = scanData.getAnnotations();
+            for (ModFileScanData.AnnotationData a : annotations)
+            {
+                if (Objects.equals(a.getAnnotationType(), annotationType))
+                {
+                    String memberName = a.getMemberName();
+                    pluginClassNames.add(memberName);
+                }
+            }
+        }
+        List<T> instances = new ArrayList<>();
+        for (String className : pluginClassNames)
+        {
+            try
+            {
+                Class<?> asmClass = Class.forName(className);
+                Class<? extends T> asmInstanceClass = asmClass.asSubclass(instanceClass);
+                Constructor<? extends T> constructor = asmInstanceClass.getDeclaredConstructor();
+                T instance = constructor.newInstance();
+                instances.add(instance);
+            }
+            catch (ReflectiveOperationException | LinkageError e)
+            {
+                LOGGER.error("Failed to load: {}", className, e);
+            }
+        }
+        return instances;
+    }
+}


### PR DESCRIPTION
Fixes #73
Fixes #62

Notes:
1. Review the code.
2. `AppleSkinPlugin` maybe is a bad name, but I don't have a better idea.
3. `AnnotatedInstanceHelper` refer code from JEI.
4. Compiled jar in 1.16.4 env, do not seem compatible to 1.16.5.
5. User can accidentally access the not squeek.appleskin.api classes/methods

## Example

```java
@AppleSkinPlugin
public class ExampleEventHandler implements AppleSkinApi {

    @Override
    public void registerEvents() {
        MinecraftForge.EVENT_BUS.register(this);
    }

    @SubscribeEvent
    public void onFoodValueEvents(FoodValuesEvent foodValuesEvent) {
        // display hunger restored as 1 for all food
        foodValuesEvent.modifiedFoodValues = new FoodValues(1, foodValuesEvent.defaultFoodValues.saturationModifier);
    }
}
```

## Configuration for `build.gradle`
1. Add `maven { url "https://maven.ryanliptak.com/" }` in the `repositories`, **not in** `buildscript.repositories`
2. Add `compileOnly fg.deobf('squeek.appleskin:appleskin-forge-mc1.16.5:2.1.0')` in the `dependencies`
3. Add `runtimeOnly fg.deobf('squeek.appleskin:appleskin-forge-mc1.16.5:2.1.0')` in the `dependencies` if needs test on run.

