### PR TITLE
Add some security checks to prevent infinite loop

### DIFF
--- a/java/squeek/appleskin/helpers/FoodHelper.java
+++ b/java/squeek/appleskin/helpers/FoodHelper.java
@@ -112,6 +112,9 @@ public class FoodHelper
 		float exhaustionForRegen = 6.0F;
 		float exhaustionForConsumed = 4.0F;
 
+		if (!Float.isFinite(exhaustionLevel) || !Float.isFinite(exhaustionLevel))
+			return 0;
+
 		while (foodLevel >= 18)
 		{
 			while (exhaustionLevel > exhaustionForConsumed)


### PR DESCRIPTION
When `exhaustionLevel` or `exhaustionLevel` is infinite or nan, we can't calculate the estimated health, this PR simply ignored, maybe we needs to throw an exception?

Port to 1.16-forge/1.16-fabirc/1.17-forge/1.17-fabirc