### PR TITLE
Updated for 1.18

### DIFF
--- a/resources/pack.mcmeta
+++ b/resources/pack.mcmeta
@@ -1,6 +1,6 @@
 {
   "pack": {
     "description": "AppleSkin resources",
-    "pack_format": 6
+    "pack_format": 8
   }
 }


### PR DESCRIPTION
Minecraft 1.18 uses pack format 8 while 1.16 used format 6.