### PR TITLE
Fix issue with poorly implemented modded consumables returning null as foodcomponents

### DIFF
--- a/java/squeek/appleskin/helpers/FoodHelper.java
+++ b/java/squeek/appleskin/helpers/FoodHelper.java
@@ -38,8 +38,8 @@ public class FoodHelper
 	public static FoodValues getDefaultFoodValues(ItemStack itemStack)
 	{
 		FoodComponent itemFood = itemStack.getItem().getFoodComponent();
-		int hunger = itemFood.getHunger();
-		float saturationModifier = itemFood.getSaturationModifier();
+		int hunger = itemFood != null ? itemFood.getHunger() : 0;
+		float saturationModifier = itemFood != null ? itemFood.getSaturationModifier() : 0;
 		return new FoodValues(hunger, saturationModifier);
 	}
 


### PR DESCRIPTION
Prevents client crash upon trying to get how to render a modded consumable's details when its `getFoodComponent` method returns null.
Includes modification for versions from 1.19 to 1.19.4 + version bump (done via cherry-picking commits)