### PR TITLE
Update to 24w14potato

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '1.4-SNAPSHOT'
+	id 'fabric-loom' version '1.5-SNAPSHOT'
 	id 'maven-publish'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ dependencies {
 	}
 	include "me.shedaniel.cloth:cloth-config-fabric:${project.cloth_version}"
 
-	modCompileOnly "me.shedaniel:RoughlyEnoughItems-fabric:14.0.687"
+	modCompileOnly "me.shedaniel:RoughlyEnoughItems-fabric:14.0.691-alpha"
 }
 
 processResources {

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,14 +6,14 @@ org.gradle.parallel=true
 # check these on https://fabricmc.net/develop
 minecraft_version=24w14potato
 yarn_mappings=24w14potato+build.1
-loader_version=0.15.0
+loader_version=0.15.9
 
 #Fabric api
 fabric_version=0.96.14+24w14potato
 
 # Third-party Properties
-cloth_version=13.0.114
-modmenu_version=9.0.0-pre.1
+cloth_version=14.0.123
+modmenu_version=10.0.0-alpha.3
 
 # Mod Properties
 maven_group = squeek.appleskin

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,12 +4,12 @@ org.gradle.parallel=true
 
 # Fabric Properties
 # check these on https://fabricmc.net/develop
-minecraft_version=1.20.3
-yarn_mappings=1.20.3+build.1
+minecraft_version=24w14potato
+yarn_mappings=24w14potato+build.1
 loader_version=0.15.0
 
 #Fabric api
-fabric_version=0.91.1+1.20.3
+fabric_version=0.96.14+24w14potato
 
 # Third-party Properties
 cloth_version=13.0.114
@@ -18,4 +18,4 @@ modmenu_version=9.0.0-pre.1
 # Mod Properties
 maven_group = squeek.appleskin
 archives_base_name = appleskin-fabric
-mod_version = 2.5.1
+mod_version = 2.5.1-potato

--- a/java/squeek/appleskin/AppleSkinCommon.java
+++ b/java/squeek/appleskin/AppleSkinCommon.java
@@ -1,0 +1,13 @@
+package squeek.appleskin;
+
+import net.fabricmc.api.ModInitializer;
+import squeek.appleskin.network.SyncHandler;
+
+public class AppleSkinCommon implements ModInitializer
+{
+	@Override
+	public void onInitialize()
+	{
+		SyncHandler.init();
+	}
+}

--- a/java/squeek/appleskin/helpers/FoodHelper.java
+++ b/java/squeek/appleskin/helpers/FoodHelper.java
@@ -1,12 +1,12 @@
 package squeek.appleskin.helpers;
 
-import com.mojang.datafixers.util.Pair;
+import net.minecraft.component.DataComponentTypes;
+import net.minecraft.component.type.FoodComponent;
 import net.minecraft.entity.effect.StatusEffectCategory;
 import net.minecraft.entity.effect.StatusEffectInstance;
 import net.minecraft.entity.effect.StatusEffects;
 import net.minecraft.entity.player.HungerManager;
 import net.minecraft.entity.player.PlayerEntity;
-import net.minecraft.item.FoodComponent;
 import net.minecraft.item.ItemStack;
 import net.minecraft.world.GameRules;
 import net.minecraft.world.World;
@@ -19,7 +19,7 @@ public class FoodHelper
 		if (itemStack.getItem() == null)
 			return false;
 
-		return itemStack.getItem().isFood();
+		return itemStack.getItem().getComponents().contains(DataComponentTypes.FOOD);
 	}
 
 	public static boolean canConsume(ItemStack itemStack, PlayerEntity player)
@@ -28,18 +28,18 @@ public class FoodHelper
 		if (!isFood(itemStack))
 			return false;
 
-		FoodComponent itemFood = itemStack.getItem().getFoodComponent();
+		FoodComponent itemFood = itemStack.getItem().getComponents().get(DataComponentTypes.FOOD);
 		if (itemFood == null)
 			return false;
 
-		return player.canConsume(itemFood.isAlwaysEdible());
+		return player.canConsume(itemFood.canAlwaysEat());
 	}
 
 	public static FoodValues getDefaultFoodValues(ItemStack itemStack)
 	{
-		FoodComponent itemFood = itemStack.getItem().getFoodComponent();
-		int hunger = itemFood != null ? itemFood.getHunger() : 0;
-		float saturationModifier = itemFood != null ? itemFood.getSaturationModifier() : 0;
+		FoodComponent itemFood = itemStack.getItem().getComponents().get(DataComponentTypes.FOOD);
+		int hunger = itemFood != null ? itemFood.nutrition() : 0;
+		float saturationModifier = itemFood != null ? itemFood.saturationModifier() : 0;
 		return new FoodValues(hunger, saturationModifier);
 	}
 
@@ -60,9 +60,9 @@ public class FoodHelper
 		if (!isFood(itemStack))
 			return false;
 
-		for (Pair<StatusEffectInstance, Float> effect : itemStack.getItem().getFoodComponent().getStatusEffects())
+		for (FoodComponent.StatusEffectEntry effect : itemStack.getItem().getComponents().get(DataComponentTypes.FOOD).effects())
 		{
-			if (effect.getFirst() != null && effect.getFirst().getEffectType() != null && effect.getFirst().getEffectType().getCategory() == StatusEffectCategory.HARMFUL)
+			if (effect.effect().getEffectType().value().getCategory() == StatusEffectCategory.HARMFUL)
 				return true;
 		}
 		return false;
@@ -91,9 +91,9 @@ public class FoodHelper
 		}
 
 		// health for regeneration effect
-		for (Pair<StatusEffectInstance, Float> effect : itemStack.getItem().getFoodComponent().getStatusEffects())
+		for (FoodComponent.StatusEffectEntry effect : itemStack.getItem().getComponents().get(DataComponentTypes.FOOD).effects())
 		{
-			StatusEffectInstance effectInstance = effect.getFirst();
+			StatusEffectInstance effectInstance = effect.effect();
 			if (effectInstance != null && effectInstance.getEffectType() == StatusEffects.REGENERATION)
 			{
 				int amplifier = effectInstance.getAmplifier();

--- a/java/squeek/appleskin/network/ClientSyncHandler.java
+++ b/java/squeek/appleskin/network/ClientSyncHandler.java
@@ -3,16 +3,12 @@ package squeek.appleskin.network;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
-import net.fabricmc.fabric.api.networking.v1.PayloadTypeRegistry;
 
 public class ClientSyncHandler
 {
 	@Environment(EnvType.CLIENT)
 	public static void init()
 	{
-		PayloadTypeRegistry.playS2C().register(ExhaustionSyncPayload.ID, ExhaustionSyncPayload.CODEC);
-		PayloadTypeRegistry.playS2C().register(SaturationSyncPayload.ID, SaturationSyncPayload.CODEC);
-
 		ClientPlayNetworking.registerGlobalReceiver(ExhaustionSyncPayload.ID, (payload, context) -> {
 			context.client().execute(() -> {
 				context.client().player.getHungerManager().setExhaustion(payload.getExhaustion());

--- a/java/squeek/appleskin/network/ClientSyncHandler.java
+++ b/java/squeek/appleskin/network/ClientSyncHandler.java
@@ -3,22 +3,24 @@ package squeek.appleskin.network;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
+import net.fabricmc.fabric.api.networking.v1.PayloadTypeRegistry;
 
 public class ClientSyncHandler
 {
 	@Environment(EnvType.CLIENT)
 	public static void init()
 	{
-		ClientPlayNetworking.registerGlobalReceiver(SyncHandler.EXHAUSTION_SYNC, (client, handler, buf, responseSender) -> {
-			float exhaustion = buf.readFloat();
-			client.execute(() -> {
-				client.player.getHungerManager().setExhaustion(exhaustion);
+		PayloadTypeRegistry.playS2C().register(ExhaustionSyncPayload.ID, ExhaustionSyncPayload.CODEC);
+		PayloadTypeRegistry.playS2C().register(SaturationSyncPayload.ID, SaturationSyncPayload.CODEC);
+
+		ClientPlayNetworking.registerGlobalReceiver(ExhaustionSyncPayload.ID, (payload, context) -> {
+			context.client().execute(() -> {
+				context.client().player.getHungerManager().setExhaustion(payload.getExhaustion());
 			});
 		});
-		ClientPlayNetworking.registerGlobalReceiver(SyncHandler.SATURATION_SYNC, (client, handler, buf, responseSender) -> {
-			float saturation = buf.readFloat();
-			client.execute(() -> {
-				client.player.getHungerManager().setSaturationLevel(saturation);
+		ClientPlayNetworking.registerGlobalReceiver(SaturationSyncPayload.ID, (payload, context) -> {
+			context.client().execute(() -> {
+				context.client().player.getHungerManager().setSaturationLevel(payload.getSaturation());
 			});
 		});
 	}

--- a/java/squeek/appleskin/network/ExhaustionSyncPayload.java
+++ b/java/squeek/appleskin/network/ExhaustionSyncPayload.java
@@ -1,0 +1,34 @@
+package squeek.appleskin.network;
+
+import net.minecraft.network.PacketByteBuf;
+import net.minecraft.network.codec.PacketCodec;
+import net.minecraft.network.packet.CustomPayload;
+
+public class ExhaustionSyncPayload implements CustomPayload {
+    public static final PacketCodec<PacketByteBuf, ExhaustionSyncPayload> CODEC = CustomPayload.codecOf(ExhaustionSyncPayload::write, ExhaustionSyncPayload::new);
+    public static final CustomPayload.Id<ExhaustionSyncPayload> ID = CustomPayload.id("appleskin:exhaustion_sync");
+
+    float exhaustion;
+
+    public ExhaustionSyncPayload(float exhaustion) {
+        this.exhaustion = exhaustion;
+    }
+
+    public ExhaustionSyncPayload(PacketByteBuf buf) {
+        this.exhaustion = buf.readFloat();
+    }
+
+    public void write(PacketByteBuf buf) {
+        buf.writeFloat(exhaustion);
+    }
+
+    public float getExhaustion() {
+        return exhaustion;
+    }
+
+    @Override
+    public Id<? extends CustomPayload> getId() {
+        return ID;
+    }
+
+}

--- a/java/squeek/appleskin/network/ExhaustionSyncPayload.java
+++ b/java/squeek/appleskin/network/ExhaustionSyncPayload.java
@@ -3,32 +3,31 @@ package squeek.appleskin.network;
 import net.minecraft.network.PacketByteBuf;
 import net.minecraft.network.codec.PacketCodec;
 import net.minecraft.network.packet.CustomPayload;
+import net.minecraft.util.Identifier;
 
-public class ExhaustionSyncPayload implements CustomPayload {
-    public static final PacketCodec<PacketByteBuf, ExhaustionSyncPayload> CODEC = CustomPayload.codecOf(ExhaustionSyncPayload::write, ExhaustionSyncPayload::new);
-    public static final CustomPayload.Id<ExhaustionSyncPayload> ID = CustomPayload.id("appleskin:exhaustion_sync");
+public record ExhaustionSyncPayload(float exhaustion) implements CustomPayload
+{
+	public static final PacketCodec<PacketByteBuf, ExhaustionSyncPayload> CODEC = CustomPayload.codecOf(ExhaustionSyncPayload::write, ExhaustionSyncPayload::new);
+	public static final CustomPayload.Id<ExhaustionSyncPayload> ID = new Id<>(new Identifier("appleskin", "exhaustion"));
 
-    float exhaustion;
+	public ExhaustionSyncPayload(PacketByteBuf buf)
+	{
+		this(buf.readFloat());
+	}
 
-    public ExhaustionSyncPayload(float exhaustion) {
-        this.exhaustion = exhaustion;
-    }
+	public void write(PacketByteBuf buf)
+	{
+		buf.writeFloat(exhaustion);
+	}
 
-    public ExhaustionSyncPayload(PacketByteBuf buf) {
-        this.exhaustion = buf.readFloat();
-    }
+	public float getExhaustion()
+	{
+		return exhaustion;
+	}
 
-    public void write(PacketByteBuf buf) {
-        buf.writeFloat(exhaustion);
-    }
-
-    public float getExhaustion() {
-        return exhaustion;
-    }
-
-    @Override
-    public Id<? extends CustomPayload> getId() {
-        return ID;
-    }
-
+	@Override
+	public Id<? extends CustomPayload> getId()
+	{
+		return ID;
+	}
 }

--- a/java/squeek/appleskin/network/SaturationSyncPayload.java
+++ b/java/squeek/appleskin/network/SaturationSyncPayload.java
@@ -1,0 +1,34 @@
+package squeek.appleskin.network;
+
+import net.minecraft.network.PacketByteBuf;
+import net.minecraft.network.codec.PacketCodec;
+import net.minecraft.network.packet.CustomPayload;
+
+public class SaturationSyncPayload implements CustomPayload {
+    public static final PacketCodec<PacketByteBuf, SaturationSyncPayload> CODEC = CustomPayload.codecOf(SaturationSyncPayload::write, SaturationSyncPayload::new);
+    public static final CustomPayload.Id<SaturationSyncPayload> ID = CustomPayload.id("appleskin:saturation_sync");
+
+    float saturation;
+
+    public SaturationSyncPayload(float saturation) {
+        this.saturation = saturation;
+    }
+
+    public SaturationSyncPayload(PacketByteBuf buf) {
+        this.saturation = buf.readFloat();
+    }
+
+    public void write(PacketByteBuf buf) {
+        buf.writeFloat(saturation);
+    }
+
+    public float getSaturation() {
+        return saturation;
+    }
+
+    @Override
+    public Id<? extends CustomPayload> getId() {
+        return ID;
+    }
+
+}

--- a/java/squeek/appleskin/network/SaturationSyncPayload.java
+++ b/java/squeek/appleskin/network/SaturationSyncPayload.java
@@ -3,32 +3,31 @@ package squeek.appleskin.network;
 import net.minecraft.network.PacketByteBuf;
 import net.minecraft.network.codec.PacketCodec;
 import net.minecraft.network.packet.CustomPayload;
+import net.minecraft.util.Identifier;
 
-public class SaturationSyncPayload implements CustomPayload {
-    public static final PacketCodec<PacketByteBuf, SaturationSyncPayload> CODEC = CustomPayload.codecOf(SaturationSyncPayload::write, SaturationSyncPayload::new);
-    public static final CustomPayload.Id<SaturationSyncPayload> ID = CustomPayload.id("appleskin:saturation_sync");
+public record SaturationSyncPayload(float saturation) implements CustomPayload
+{
+	public static final PacketCodec<PacketByteBuf, SaturationSyncPayload> CODEC = CustomPayload.codecOf(SaturationSyncPayload::write, SaturationSyncPayload::new);
+	public static final CustomPayload.Id<SaturationSyncPayload> ID = new Id<>(new Identifier("appleskin", "saturation"));
 
-    float saturation;
+	public SaturationSyncPayload(PacketByteBuf buf)
+	{
+		this(buf.readFloat());
+	}
 
-    public SaturationSyncPayload(float saturation) {
-        this.saturation = saturation;
-    }
+	public void write(PacketByteBuf buf)
+	{
+		buf.writeFloat(saturation);
+	}
 
-    public SaturationSyncPayload(PacketByteBuf buf) {
-        this.saturation = buf.readFloat();
-    }
+	public float getSaturation()
+	{
+		return saturation;
+	}
 
-    public void write(PacketByteBuf buf) {
-        buf.writeFloat(saturation);
-    }
-
-    public float getSaturation() {
-        return saturation;
-    }
-
-    @Override
-    public Id<? extends CustomPayload> getId() {
-        return ID;
-    }
-
+	@Override
+	public Id<? extends CustomPayload> getId()
+	{
+		return ID;
+	}
 }

--- a/java/squeek/appleskin/network/SyncHandler.java
+++ b/java/squeek/appleskin/network/SyncHandler.java
@@ -1,10 +1,8 @@
 package squeek.appleskin.network;
 
-import io.netty.buffer.Unpooled;
+import net.fabricmc.fabric.api.networking.v1.PayloadTypeRegistry;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
-import net.minecraft.network.PacketByteBuf;
 import net.minecraft.server.network.ServerPlayerEntity;
-import net.minecraft.util.Identifier;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -12,6 +10,11 @@ import java.util.UUID;
 
 public class SyncHandler
 {
+	public static void init()
+	{
+		PayloadTypeRegistry.playS2C().register(ExhaustionSyncPayload.ID, ExhaustionSyncPayload.CODEC);
+		PayloadTypeRegistry.playS2C().register(SaturationSyncPayload.ID, SaturationSyncPayload.CODEC);
+	}
 
 	/*
 	 * Sync saturation (vanilla MC only syncs when it hits 0)

--- a/java/squeek/appleskin/network/SyncHandler.java
+++ b/java/squeek/appleskin/network/SyncHandler.java
@@ -12,15 +12,6 @@ import java.util.UUID;
 
 public class SyncHandler
 {
-	public static final Identifier EXHAUSTION_SYNC = new Identifier("appleskin", "exhaustion_sync");
-	public static final Identifier SATURATION_SYNC = new Identifier("appleskin", "saturation_sync");
-
-	private static PacketByteBuf makePacketBuf(float val)
-	{
-		PacketByteBuf buf = new PacketByteBuf(Unpooled.buffer());
-		buf.writeFloat(val);
-		return buf;
-	}
 
 	/*
 	 * Sync saturation (vanilla MC only syncs when it hits 0)
@@ -37,14 +28,14 @@ public class SyncHandler
 		float saturation = player.getHungerManager().getSaturationLevel();
 		if (lastSaturationLevel == null || lastSaturationLevel != saturation)
 		{
-			ServerPlayNetworking.send(player, SATURATION_SYNC, makePacketBuf(saturation));
+			ServerPlayNetworking.send(player, new SaturationSyncPayload(saturation));
 			lastSaturationLevels.put(player.getUuid(), saturation);
 		}
 
 		float exhaustionLevel = player.getHungerManager().getExhaustion();
 		if (lastExhaustionLevel == null || Math.abs(lastExhaustionLevel - exhaustionLevel) >= 0.01f)
 		{
-			ServerPlayNetworking.send(player, EXHAUSTION_SYNC, makePacketBuf(exhaustionLevel));
+			ServerPlayNetworking.send(player, new ExhaustionSyncPayload(exhaustionLevel));
 			lastExhaustionLevels.put(player.getUuid(), exhaustionLevel);
 		}
 	}

--- a/resources/fabric.mod.json
+++ b/resources/fabric.mod.json
@@ -22,6 +22,9 @@
     "client": [
       "squeek.appleskin.AppleSkin"
     ],
+    "main": [
+      "squeek.appleskin.AppleSkinCommon"
+    ],
     "modmenu": [
       "squeek.appleskin.gui.ModMenuIntegration"
     ],


### PR DESCRIPTION
Since I was porting some mods I can't live without, I thought it would be cool to have this as well.

The mod is not free of errors. I noticed this render artifact:

![grafik](https://github.com/squeek502/AppleSkin/assets/117233381/d52ba56d-6bc3-4f6c-9cad-1c8496758c52)

The hunerbar has also some transparency issue when indicating newly added food when holding an item and not fully fed:

![grafik](https://github.com/squeek502/AppleSkin/assets/117233381/6595823d-3c15-45e4-8584-9bebba0aff68)

Also, while I updated the CustomPayload to the new architecture, it could not test it yet (thought it starts which is already a good indicator).

This might be a useful stepping stone. Just verify that the server plugin integration works, fix the 2 render artifacts, and it should probably be 90% done for 1.20.5 as fabric calls the version "1.20.5-alpha.24.12.potato" in the `fabric.mod.json`.

I didn't test or try to port Forge. Only Fabric.