### PR TITLE
Update homepage URL for AppleSkin mod

### DIFF
--- a/resources/fabric.mod.json
+++ b/resources/fabric.mod.json
@@ -10,7 +10,7 @@
   ],
   "contact": {
     "sources": "https://github.com/squeek502/AppleSkin",
-    "homepage": "https://minecraft.curseforge.com/projects/appleskin",
+    "homepage": "https://modrinth.com/mod/appleskin",
     "issues": "https://github.com/squeek502/AppleSkin/issues"
   },
 


### PR DESCRIPTION
The Cursforge link no longer exists.