### PR TITLE
[1.21.1 Neoforge] Update Gradle to 9.3.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
 	id 'eclipse'
 	id 'idea'
 	id 'maven-publish'
-	id 'net.neoforged.gradle.userdev' version '7.0.142'
+	id 'net.neoforged.gradle.userdev' version '7.1.21'
 }
 
 java.toolchain.languageVersion = JavaLanguageVersion.of(21)
@@ -24,7 +24,7 @@ runs {
 
 	server {
 		systemProperty 'forge.enabledGameTestNamespaces', project.mod_id
-		programArgument '--nogui'
+		argument '--nogui'
 	}
 
 	gameTestServer {
@@ -33,9 +33,11 @@ runs {
 }
 
 group = project.maven_group
-archivesBaseName = project.archives_base_name
 version = "mc" + project.minecraft_version + "-" + project.mod_version
 def semver_version = project.mod_version + "+mc" + project.minecraft_version
+base {
+	archivesName = project.archives_base_name
+}
 
 sourceSets.main.java.srcDirs += 'java'
 sourceSets.main.java.srcDirs += 'apis'
@@ -79,7 +81,7 @@ publishing {
 	publications {
 		mavenJava(MavenPublication) {
 			groupId = group
-			artifactId = archivesBaseName
+			artifactId = project.archives_base_name
 
 			// add all the jars that should be included when publishing to maven
 			artifact(jar)

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
# Motivation
I recently tried to include AppleSkin using `includeBuild` but due to NeoGradle being outdated, it failed to configure AppleSkin when my root project used Gradle 9.0
This PR upgrades NeoGradle and Gradle version so that it follows official MDK recommendation and it's easier to include it into other projects.
Comparing it with build.gradle of 1.21.11, it's almost identical. Except this one does not use access transformer.