### PR TITLE
Add FoodCheckEvent

### DIFF
--- a/java/squeek/appleskin/api/event/FoodCheckEvent.java
+++ b/java/squeek/appleskin/api/event/FoodCheckEvent.java
@@ -1,0 +1,27 @@
+package squeek.appleskin.api.event;
+
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+import net.neoforged.bus.api.Event;
+
+/**
+ * Can be used to treat non-standard items as food for display purposes
+ * or if you have a food component specific to your mod.
+ * Called whenever an item is checked if it should show food tooltips.
+ * <p>
+ * Note: if the item lacks default food components, make sure to also
+ * listen to {@link FoodValuesEvent}, otherwise the tooltip will be empty.
+ */
+public class FoodCheckEvent extends Event
+{
+    public FoodCheckEvent(Player player, ItemStack itemStack, boolean isFood)
+    {
+        this.isFood = isFood;
+        this.player = player;
+        this.itemStack = itemStack;
+    }
+
+    public boolean isFood;
+    public final ItemStack itemStack;
+    public final Player player;
+}

--- a/java/squeek/appleskin/helpers/FoodHelper.java
+++ b/java/squeek/appleskin/helpers/FoodHelper.java
@@ -12,6 +12,7 @@ import net.minecraft.world.item.component.Consumables;
 import net.minecraft.world.item.consume_effects.ApplyStatusEffectsConsumeEffect;
 import net.neoforged.neoforge.common.NeoForge;
 import org.jetbrains.annotations.Nullable;
+import squeek.appleskin.api.event.FoodCheckEvent;
 import squeek.appleskin.api.event.FoodValuesEvent;
 import squeek.appleskin.network.MessageNaturalRegenerationSync;
 
@@ -19,7 +20,12 @@ public class FoodHelper
 {
 	public static boolean isFood(ItemStack itemStack, Player player)
 	{
-		return itemStack.get(DataComponents.FOOD) != null && itemStack.get(DataComponents.CONSUMABLE) != null;
+		boolean result = itemStack.get(DataComponents.FOOD) != null && itemStack.get(DataComponents.CONSUMABLE) != null;
+
+		FoodCheckEvent event = new FoodCheckEvent(player, itemStack, result);
+		NeoForge.EVENT_BUS.post(event);
+
+		return event.isFood;
 	}
 
 	public static boolean canConsume(Player player, FoodProperties foodProperties)


### PR DESCRIPTION
This PR adds FoodCheckEvent, which allows mods to treat non-standard items as food without mixining into isFood.

Currently isFood only checks for vanilla DataComponents.FOOD and DataComponents.CONSUMABLE, which means mods using custom food components have to mixin AppleSkin to get the tooltips working. This event should allow to do this without mixins.

I ran into this while working on a mod that where I use a custom analogue of DataComponents.FOOD for internal reasons. I can adjust the implementation if needed.